### PR TITLE
fixed editor height and width issue and added extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typwriter",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "",
   "type": "module",
   "scripts": {
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@citedrive/codemirror-lang-bibtex": "^6.4.1",
     "@codemirror/autocomplete": "^6.18.7",
     "@codemirror/commands": "^6.8.1",
     "@codemirror/lang-yaml": "^6.1.2",
@@ -22,6 +23,8 @@
     "@codemirror/view": "^6.38.2",
     "@ddietr/codemirror-themes": "^1.5.2",
     "@lezer/highlight": "^1.2.1",
+    "@replit/codemirror-indentation-markers": "^6.5.3",
+    "@replit/codemirror-vscode-keymap": "^6.0.2",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "~2",
     "@tauri-apps/plugin-fs": "~2.4.2",
@@ -30,6 +33,7 @@
     "@tauri-apps/plugin-updater": "~2.9.0",
     "@tauri-store/svelte": "^2.6.1",
     "codemirror": "^6.0.2",
+    "codemirror-extension-inline-suggestion": "^0.0.3",
     "codemirror-lang-typst": "^0.4.0",
     "eslint-plugin-neverthrow": "^1.1.4",
     "neverthrow": "^8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@citedrive/codemirror-lang-bibtex':
+        specifier: ^6.4.1
+        version: 6.4.1
       '@codemirror/autocomplete':
         specifier: ^6.18.7
         version: 6.18.7
@@ -35,6 +38,12 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.1
         version: 1.2.1
+      '@replit/codemirror-indentation-markers':
+        specifier: ^6.5.3
+        version: 6.5.3(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)
+      '@replit/codemirror-vscode-keymap':
+        specifier: ^6.0.2
+        version: 6.0.2(@codemirror/autocomplete@6.18.7)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)
       '@tauri-apps/api':
         specifier: ^2.8.0
         version: 2.8.0
@@ -59,6 +68,9 @@ importers:
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
+      codemirror-extension-inline-suggestion:
+        specifier: ^0.0.3
+        version: 0.0.3(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)
       codemirror-lang-typst:
         specifier: ^0.4.0
         version: 0.4.0
@@ -149,6 +161,9 @@ importers:
         version: 3.5.0(vite@6.3.5(jiti@2.5.1)(lightningcss@1.30.1))
 
 packages:
+
+  '@citedrive/codemirror-lang-bibtex@6.4.1':
+    resolution: {integrity: sha512-KAug5gV7RoQ3PXxZsrh2THnmXTQIN/4OtDh3VbRRqkOP3z7ZJ2cZXe9QNWatha+ZmRRYOt2rz3k4I3/ZPHZ2Ww==}
 
   '@codemirror/autocomplete@6.18.7':
     resolution: {integrity: sha512-8EzdeIoWPJDsMBwz3zdzwXnUpCzMiCyz5/A3FIPpriaclFCGDkAzK13sMcnsu5rowqiyeQN2Vs2TsOcoDPZirQ==}
@@ -422,6 +437,9 @@ packages:
   '@lezer/common@1.2.3':
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
 
+  '@lezer/go@1.0.1':
+    resolution: {integrity: sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==}
+
   '@lezer/highlight@1.2.1':
     resolution: {integrity: sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==}
 
@@ -453,6 +471,24 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@replit/codemirror-indentation-markers@6.5.3':
+    resolution: {integrity: sha512-hL5Sfvw3C1vgg7GolLe/uxX5T3tmgOA3ZzqlMv47zjU1ON51pzNWiVbS22oh6crYhtVhv8b3gdXwoYp++2ilHw==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+
+  '@replit/codemirror-vscode-keymap@6.0.2':
+    resolution: {integrity: sha512-j45qTwGxzpsv82lMD/NreGDORFKSctMDVkGRopaP+OrzSzv+pXDQuU3LnFvKpasyjVT0lf+PKG1v2DSCn/vxxg==}
+    peerDependencies:
+      '@codemirror/autocomplete': ^6.0.0
+      '@codemirror/commands': ^6.0.0
+      '@codemirror/language': ^6.0.0
+      '@codemirror/lint': ^6.0.0
+      '@codemirror/search': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
 
   '@rollup/plugin-virtual@3.0.2':
     resolution: {integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==}
@@ -958,6 +994,12 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bibtex-tidy@https://codeload.github.com/flamingtempura/bibtex-tidy/tar.gz/83734f920a28cc69b680d8a1041d48ec8379d5ef:
+    resolution: {tarball: https://codeload.github.com/flamingtempura/bibtex-tidy/tar.gz/83734f920a28cc69b680d8a1041d48ec8379d5ef}
+    version: 1.14.0
+    engines: {node: '>12'}
+    hasBin: true
+
   bits-ui@2.11.4:
     resolution: {integrity: sha512-OlVBJhNUMDHbIAf8oDAyPchIrU8b1S5NAMm6enMZSKx5HKcf/QPI485/BL1r4EPlv4O3m45e59hBRCETtYFdxg==}
     engines: {node: '>=20'}
@@ -994,6 +1036,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  codemirror-extension-inline-suggestion@0.0.3:
+    resolution: {integrity: sha512-IgNoyK7d4HJicqZMYMC1RgHlpR1pnSEgDHATKIuQrqW68o5QmD8IFZ26M/8UXNI+Usb00Vu4q0EtzMdm92pOAg==}
+    peerDependencies:
+      '@codemirror/state': ^6.2.0
+      '@codemirror/view': ^6.7.2
 
   codemirror-lang-typst@0.4.0:
     resolution: {integrity: sha512-jpHz5qQRC3LE48JH+C24qZJAEAhjqRzWA4MFodPaxriz7UwLVuTLCQ672rdDx9ziObBQ2BvHaRIm5/Upz4KoBQ==}
@@ -1740,6 +1788,16 @@ packages:
 
 snapshots:
 
+  '@citedrive/codemirror-lang-bibtex@6.4.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.18.7
+      '@codemirror/language': 6.11.3
+      '@codemirror/lint': 6.8.5
+      '@codemirror/state': 6.5.2
+      '@lezer/common': 1.2.3
+      '@lezer/go': 1.0.1
+      bibtex-tidy: https://codeload.github.com/flamingtempura/bibtex-tidy/tar.gz/83734f920a28cc69b680d8a1041d48ec8379d5ef
+
   '@codemirror/autocomplete@6.18.7':
     dependencies:
       '@codemirror/language': 6.11.3
@@ -1976,6 +2034,12 @@ snapshots:
 
   '@lezer/common@1.2.3': {}
 
+  '@lezer/go@1.0.1':
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
+
   '@lezer/highlight@1.2.1':
     dependencies:
       '@lezer/common': 1.2.3
@@ -2009,6 +2073,22 @@ snapshots:
       fastq: 1.19.1
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@replit/codemirror-indentation-markers@6.5.3(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)':
+    dependencies:
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.2
+
+  '@replit/codemirror-vscode-keymap@6.0.2(@codemirror/autocomplete@6.18.7)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.2)':
+    dependencies:
+      '@codemirror/autocomplete': 6.18.7
+      '@codemirror/commands': 6.8.1
+      '@codemirror/language': 6.11.3
+      '@codemirror/lint': 6.8.5
+      '@codemirror/search': 6.5.11
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.2
 
   '@rollup/plugin-virtual@3.0.2(rollup@4.50.0)':
     optionalDependencies:
@@ -2432,6 +2512,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bibtex-tidy@https://codeload.github.com/flamingtempura/bibtex-tidy/tar.gz/83734f920a28cc69b680d8a1041d48ec8379d5ef: {}
+
   bits-ui@2.11.4(@internationalized/date@3.9.0)(svelte@5.38.7):
     dependencies:
       '@floating-ui/core': 1.7.3
@@ -2470,6 +2552,11 @@ snapshots:
   chownr@3.0.0: {}
 
   clsx@2.1.1: {}
+
+  codemirror-extension-inline-suggestion@0.0.3(@codemirror/state@6.5.2)(@codemirror/view@6.38.2):
+    dependencies:
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.2
 
   codemirror-lang-typst@0.4.0:
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7153,7 +7153,7 @@ dependencies = [
 
 [[package]]
 name = "typwriter"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typwriter"
-version = "0.4.7"
+version = "0.4.8"
 description = "A typst editor built with Tauri and Svelte"
 authors = ["ade"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "typwriter",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "identifier": "com.ahdey.typwriter",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -219,8 +219,8 @@
         <CodeMirror
             bind:value={editorStore.content}
             styles={{
-                "&": { height: "95svh", width: "100%" },
-                ".cm-scroller": { overflow: "auto" },
+                "&": { height: "100%", width: "100%" },
+                ".cm-scroller": { overflow: "scroll" },
             }}
             onready={async (e) => {
                 // console.log("Editor ready");

--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -34,6 +34,11 @@
     import { keymap } from "@codemirror/view";
     import { toast } from "svelte-sonner";
     // import { toast } from "svelte-sonner";
+    //
+    import { bibtex } from "@citedrive/codemirror-lang-bibtex";
+    import { indentationMarkers } from "@replit/codemirror-indentation-markers";
+    import { vscodeKeymap } from "@replit/codemirror-vscode-keymap";
+    // import { inlineSuggestion } from 'codemirror-extension-inline-suggestion';
 
     const editableDocs = ["typ", "yaml", "yml", "txt", "md", "json", "bib"];
 
@@ -94,6 +99,8 @@
             documentExtension.ext === "yml"
         ) {
             return yaml();
+        } else if (documentExtension.ext === "bib") {
+            return bibtex();
         }
         return undefined;
     });
@@ -101,19 +108,22 @@
     let languageSpecificExtensions = $derived.by(() => {
         const path = documentExtension.path;
         // console.log("Language Extensions for:", path);
-
+        const extensions = [keymap.of(vscodeKeymap), indentationMarkers()];
         switch (documentExtension.ext) {
             case "typ": {
-                return [
-                    hoverTooltip(typst_hover_tooltip),
-                    typstLinter(editorStore.diagnostics),
-                ];
+                extensions.push(
+                    ...[
+                        hoverTooltip(typst_hover_tooltip),
+                        typstLinter(editorStore.diagnostics),
+                    ],
+                );
+                break;
             }
             case "yaml":
-                return [];
+                break;
             default:
-                return [];
         }
+        return extensions;
     });
 
     // update the current file source
@@ -219,8 +229,11 @@
         <CodeMirror
             bind:value={editorStore.content}
             styles={{
-                "&": { height: "100%", width: "100%" },
-                ".cm-scroller": { overflow: "scroll" },
+                "&": {
+                    height: "100%",
+                    width: "100%",
+                },
+                ".cm-scroller": { overflow: "auto" },
             }}
             onready={async (e) => {
                 // console.log("Editor ready");
@@ -235,6 +248,7 @@
             lineWrapping
             lineNumbers
             foldGutter
+            indentOnInput
             editable={editableDocs.includes(documentExtension.ext)}
             autocompletion={completion}
             theme={currentTheme.editor}
@@ -249,3 +263,11 @@
         />
     {/key}
 {/if}
+
+<style>
+    :global {
+        .codemirror-wrapper {
+            width: 100%;
+        }
+    }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,7 +17,7 @@
     let { data }: { data: LayoutData } = $props();
 </script>
 
-<main class="flex-1 w-screen h-[95svh]">
+<main class=" w-[100svw] h-[94svh]">
     <Resizable.PaneGroup class=" h-full w-full mt-0.5" direction="horizontal">
         <!-- {#if appContext.isFileTreeOpen} -->
         <Resizable.Pane
@@ -51,7 +51,7 @@
 {#snippet EditorAndDiagnosticGroup()}
     <Resizable.PaneGroup direction="vertical">
         <Resizable.Pane defaultSize={70}>
-            <div class="h-full w-full overflow-hidden flex grow flex-1">
+            <div class="h-full w-full overflow-hidden flex grow">
                 {#if editorStore.file_path && ["typ", "yaml", "yml", "bib"].includes(getFileType(editorStore.file_path))}
                     <Editor />
                 {:else if editorStore.file_path && ["png", "jpg", "jpeg", "gif", "bmp", "webp", "svg"].includes(getFileType(editorStore.file_path))}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,7 +17,7 @@
     let { data }: { data: LayoutData } = $props();
 </script>
 
-<main class="flex-1 w-screen">
+<main class="flex-1 w-screen h-[95svh]">
     <Resizable.PaneGroup class=" h-full w-full mt-0.5" direction="horizontal">
         <!-- {#if appContext.isFileTreeOpen} -->
         <Resizable.Pane
@@ -50,8 +50,8 @@
 
 {#snippet EditorAndDiagnosticGroup()}
     <Resizable.PaneGroup direction="vertical">
-        <Resizable.Pane>
-            <div class="h-[95svh]">
+        <Resizable.Pane defaultSize={70}>
+            <div class="h-full w-full overflow-hidden flex grow flex-1">
                 {#if editorStore.file_path && ["typ", "yaml", "yml", "bib"].includes(getFileType(editorStore.file_path))}
                     <Editor />
                 {:else if editorStore.file_path && ["png", "jpg", "jpeg", "gif", "bmp", "webp", "svg"].includes(getFileType(editorStore.file_path))}

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,6 +35,9 @@ export default defineConfig(async () => ({
       "@codemirror/view",
       "@lezer/highlight",
       "thememirror",
+      "@replit/codemirror-indentation-markers",
+      "@citedrive/codemirror-lang-bibtex",
+      "@replit/codemirror-vscode-keymap",
     ],
   },
 


### PR DESCRIPTION
This pull request updates the Typwriter editor to version 0.4.8 and introduces several enhancements to the code editing experience, especially for `.bib` files and general usability. The changes include new dependencies for BibTeX language support, indentation markers, and VSCode-style keybindings, as well as UI improvements for the editor layout and sizing.

**Editor feature enhancements:**

* Added BibTeX language support in the editor by including the `@citedrive/codemirror-lang-bibtex` package and updating the editor logic to recognize `.bib` files. (`package.json`, `pnpm-lock.yaml`, `src/lib/components/editor/editor.svelte`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R16) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R13) [[3]](diffhunk://#diff-a3107c715900ad32757677f4499e18fb6e06ce383f05947dfe44b00b454b6ec7R37-R41) [[4]](diffhunk://#diff-a3107c715900ad32757677f4499e18fb6e06ce383f05947dfe44b00b454b6ec7R102-R126)
* Integrated indentation markers and VSCode keybindings using `@replit/codemirror-indentation-markers` and `@replit/codemirror-vscode-keymap`, improving code readability and keyboard shortcut familiarity. (`package.json`, `pnpm-lock.yaml`, `src/lib/components/editor/editor.svelte`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R26-R27) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR41-R46) [[3]](diffhunk://#diff-a3107c715900ad32757677f4499e18fb6e06ce383f05947dfe44b00b454b6ec7R102-R126)

**UI and layout improvements:**

* Updated editor and main page layout to use full available viewport size, improving usability and consistency across different screen sizes. (`src/lib/components/editor/editor.svelte`, `src/routes/+page.svelte`) [[1]](diffhunk://#diff-a3107c715900ad32757677f4499e18fb6e06ce383f05947dfe44b00b454b6ec7L222-R235) [[2]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL20-R20) [[3]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL53-R54)
* Added a global style for the CodeMirror wrapper to ensure 100% width in the editor component. (`src/lib/components/editor/editor.svelte`)

**Version updates and configuration:**

* Bumped application version to 0.4.8 in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` to reflect these changes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39L3-R3) [[3]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L4-R4)
* Updated Vite configuration to optimize bundling for new CodeMirror extensions. (`vite.config.js`)